### PR TITLE
✨ Feat: 트렌드 미션 페이지 생성 및 목록 조회 API

### DIFF
--- a/trend_missions/models.py
+++ b/trend_missions/models.py
@@ -63,7 +63,7 @@ class UserTrendItem(models.Model):
     content = models.CharField(max_length=300, verbose_name="트렌드 아이템 인증 내용")
 
     def __str__(self):
-        return self.user_id.nickname + "의 " + self.trend_item_id.name
+        return self.user_id.nickname + "의 " + self.trend_mission_id.trend_id.name + " 트렌드 미션의 " + self.trend_item_id.title
 
 
 class Stamp(models.Model):

--- a/trend_missions/serializers.py
+++ b/trend_missions/serializers.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+from .models import TrendMission
+
+class PostTrendMissionsSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = TrendMission
+    fields = ['user_id', 'trend_id']
+
+class TrendMissionsSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = TrendMission
+    fields = '__all__'

--- a/trend_missions/tests.py
+++ b/trend_missions/tests.py
@@ -1,3 +1,66 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+from .models import TrendMission, TrendItem
+from accounts.models import User
+from trends.models import Trend
 
-# Create your tests here.
+# 미션 페이지 생성 테스트
+class CreateTrendMissionAPITestCase(TestCase):
+    def setUp(self):
+        # 테스트를 위한 유저 생성
+        self.client = Client()
+        self.user = User.objects.create_user(
+            "testuser", "testemail@test.com", "123456789@"
+        )
+
+        # 테스트를 위한 트렌드 생성
+        self.trend = Trend.objects.create(
+            name="test-trend",
+        )
+
+        # 테스트를 위한 트렌드 아이템 생성
+        self.trend_item1 = TrendItem.objects.create(
+            title="test-trend-item1",
+            content="test-trend-item-content1",
+            image="test-trend-item-image1",
+        )
+        self.trend_item1.trend_id.set([self.trend])
+
+        self.trend_item2 = TrendItem.objects.create(
+            title="test-trend-item2",
+            content="test-trend-item-content2",
+            image="test-trend-item-image2",
+        )
+        self.trend_item2.trend_id.set([self.trend])
+
+        self.trend_item3 = TrendItem.objects.create(
+            title="test-trend-item3",
+            content="test-trend-item-content3",
+            image="test-trend-item-image3",
+        )
+        self.trend_item3.trend_id.set([self.trend])
+
+    # 정상 작동 테스트  
+    def test_createTrendMission_success(self):
+        response = self.client.post(
+            "/trend-missions/create/",
+            {"user_id": self.user.id, "trend_id": self.trend.id},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    # 비정상 작동 테스트
+    # 이미 생성된 경우 400 에러
+    def test_already_createTrendMission_fail(self):
+        
+        # 트렌드 미션 미리 생성
+        TrendMission.objects.create(
+            user_id=self.user,
+            trend_id=self.trend,
+        )
+
+        # 이미 생성된 트렌드 미션 생성 요청
+        response = self.client.post(
+            "/trend-missions/create/",
+            {"user_id": self.user.id, "trend_id": self.trend.id},
+        )
+        self.assertEqual(response.status_code, 404)

--- a/trend_missions/tests.py
+++ b/trend_missions/tests.py
@@ -43,7 +43,7 @@ class CreateTrendMissionAPITestCase(TestCase):
     # 정상 작동 테스트  
     def test_createTrendMission_success(self):
         response = self.client.post(
-            "/trend-missions/create/",
+            "/trend-missions/create",
             {"user_id": self.user.id, "trend_id": self.trend.id},
         )
         self.assertEqual(response.status_code, 200)
@@ -60,7 +60,53 @@ class CreateTrendMissionAPITestCase(TestCase):
 
         # 이미 생성된 트렌드 미션 생성 요청
         response = self.client.post(
-            "/trend-missions/create/",
+            "/trend-missions/create",
             {"user_id": self.user.id, "trend_id": self.trend.id},
         )
         self.assertEqual(response.status_code, 404)
+
+
+# 특정 사용자의 미션 리스트 조회 테스트
+# http://127.0.0.1:8000/trend-missions/{userid}
+
+class TrendMissionListAPITestCase(TestCase):
+    def setUp(self):
+        # 테스트를 위한 유저 생성
+        self.client = Client()
+        self.user = User.objects.create_user(
+            "testuser", "testemail@test.com", "123456789@"
+        )
+
+        # 테스트를 위한 트렌드 생성
+        self.trend1 = Trend.objects.create(
+            name="test-trend1",
+        )
+
+        self.trend2 = Trend.objects.create(
+            name="test-trend2",
+        )
+    
+    # 정상 작동 테스트
+    def test_getTrendMissionList_success(self):
+        # 트렌드 미션 미리 생성
+        TrendMission.objects.create(
+            user_id=self.user,
+            trend_id=self.trend1,
+        )
+
+        TrendMission.objects.create(
+            user_id=self.user,
+            trend_id=self.trend1,
+        )
+        response = self.client.get(f"/trend-missions/{self.user.id}")
+
+        self.assertEqual(response.status_code, 200)
+    
+    # 비정상 작동 테스트
+    # 정확하게는 비정상이 아닌, 트렌드 미션을 생성하지 않은 경우 빈 배열 반환
+
+    def test_getTrendMissionList_not_have_list(self):
+        response = self.client.get(f"/trend-missions/{self.user.id}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])
+

--- a/trend_missions/urls.py
+++ b/trend_missions/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("create/", views.PostTrendMissionView.as_view(), name="post_trend_mission"),
+    path("create", views.PostTrendMissionView.as_view(), name="post_trend_mission"),
+    path("<int:pk>", views.TrendMissionListView.as_view(), name="trend_mission_list"),
 ]

--- a/trend_missions/urls.py
+++ b/trend_missions/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("create/", views.PostTrendMissionView.as_view(), name="post_trend_mission"),
+]

--- a/trend_missions/views.py
+++ b/trend_missions/views.py
@@ -42,3 +42,11 @@ class PostTrendMissionView(GenericAPIView):
             result["trend_item_list"] = trend_item_list.values()  # 트렌드 아이템도 담아서 전달
             return Response(result, status=200)
         return Response(serializer.errors)
+    
+class TrendMissionListView(GenericAPIView):
+    # 사용자의 트렌드 미션 리스트 조회
+    def get(self, request, pk):
+        trend_mission = TrendMission.objects.filter(user_id=pk)
+        serializer = TrendMissionsSerializer(trend_mission, many=True)
+        return Response(serializer.data, status=200)
+    

--- a/trend_missions/views.py
+++ b/trend_missions/views.py
@@ -1,3 +1,44 @@
 from django.shortcuts import render
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework.generics import CreateAPIView, GenericAPIView
+
+# serializers
+from .serializers import PostTrendMissionsSerializer, TrendMissionsSerializer
+
+# models
+from .models import TrendMission, UserTrendItem
+from trends.models import TrendItem, Trend
+from accounts.models import User
+
 
 # Create your views here.
+class PostTrendMissionView(GenericAPIView):
+    # 트렌드 인증 미션 생성
+    def post(self, request):
+        # 이미 생성된 트렌드 미션인지 확인
+        if TrendMission.objects.filter(
+            user_id=request.data["user_id"], trend_id=request.data["trend_id"]
+        ).exists():
+            return Response("이미 생성된 트렌드 미션입니다.", status=404)
+
+        serializer = PostTrendMissionsSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+
+            # 트렌드 미션을 생성하면, 해당하는 트렌드 아이템들을 유저에게 개인적으로 할당
+            trend = request.data["trend_id"]
+            trend_item_list = TrendItem.objects.filter(trend_id=trend)
+
+            for trend_item in trend_item_list:
+                UserTrendItem.objects.create(
+                    user_id=User.objects.get(pk=request.data["user_id"]),
+                    trend_mission_id=TrendMission.objects.get(
+                        user_id=request.data["user_id"], trend_id=trend
+                    ),
+                    trend_item_id=trend_item,
+                )
+            result = serializer.data
+            result["trend_item_list"] = trend_item_list.values()  # 트렌드 아이템도 담아서 전달
+            return Response(result, status=200)
+        return Response(serializer.errors)


### PR DESCRIPTION
- 기능
  - trend_mission > urls.py 생성
  - 트렌드 미션을 생성하는 create/, <int:pk> url 추가
  - 로그인한 사용자는 해당하는 트렌드에 대한 미션 페이지 생성 가능
  - 이미 생성된 경우 404 에러 반환
  - 사용자의 id로 참여중인 트렌드 미션 리스트 조회
  - 없다면 빈 배열 반환 (에러X)

- 수정사항
  - TrendMission 모델의 __str__(self) 수정

Resolves: #7 #17

## PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] 변경 사항에 대한 테스트를 했습니다.

![image](https://github.com/HotCake-Tanghuru/HotCake-BE/assets/79897135/b76172b1-94b2-4fdd-8654-ed6894034b47)
![image](https://github.com/HotCake-Tanghuru/HotCake-BE/assets/79897135/958d08c8-38e9-4d1b-acb3-e3c4a4560c28)

