### PR TITLE
✨Feat: 트렌드 미션 페이지 상세 조회

### DIFF
--- a/trend_missions/serializers.py
+++ b/trend_missions/serializers.py
@@ -9,4 +9,5 @@ class PostTrendMissionsSerializer(serializers.ModelSerializer):
 class TrendMissionsSerializer(serializers.ModelSerializer):
   class Meta:
     model = TrendMission
-    fields = '__all__'
+    fields = ['id', 'user_id', 'trend_id', 'is_all_certificated', 'view_count']
+  

--- a/trend_missions/tests.py
+++ b/trend_missions/tests.py
@@ -110,3 +110,56 @@ class TrendMissionListAPITestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [])
 
+
+# 트렌드 미션 상세 조회 테스트
+class TrendMissionDetailAPITestCase(TestCase):
+    def setUp(self):
+        # 테스트를 위한 유저 생성
+        self.client = Client()
+        self.user = User.objects.create_user(
+            "testuser", "testemail@test.com", "123456789@"
+        )
+
+        # 테스트를 위한 트렌드 생성
+        self.trend = Trend.objects.create(
+            name="test-trend1",
+        )
+
+        # 테스트를 위한 트렌드 아이템 생성
+        self.trend_item1 = TrendItem.objects.create(
+            title="test-trend-item1",
+            content="test-trend-item-content1",
+            image="test-trend-item-image1",
+        )
+        self.trend_item1.trend_id.set([self.trend])
+
+        self.trend_item2 = TrendItem.objects.create(
+            title="test-trend-item2",
+            content="test-trend-item-content2",
+            image="test-trend-item-image2",
+        )
+        self.trend_item2.trend_id.set([self.trend])
+
+        self.trend_item3 = TrendItem.objects.create(
+            title="test-trend-item3",
+            content="test-trend-item-content3",
+            image="test-trend-item-image3",
+        )
+        self.trend_item3.trend_id.set([self.trend])
+
+        # 사용자 트렌드 미션 생성
+        self.trend_mission = TrendMission.objects.create(
+            user_id=self.user,
+            trend_id=self.trend,
+        )
+
+    # 트렌드 미션 상세 조회 성공 테스트
+    def test_TrendMissions_detail(self):
+        response = self.client.get(f"/trend-missions/about/{self.trend_mission.id}")
+        self.assertEqual(response.status_code, 200)
+
+    # 트렌드 미션 상세 조회 실패 테스트
+    def test_TrendMissions_detail_fail(self):
+        response = self.client.get(f"/trend-missions/about/-2")
+        self.assertEqual(response.status_code, 404)
+        

--- a/trend_missions/urls.py
+++ b/trend_missions/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path("create", views.PostTrendMissionView.as_view(), name="post_trend_mission"),
     path("<int:pk>", views.TrendMissionListView.as_view(), name="trend_mission_list"),
+    path("about/<int:pk>", views.TrendMissionDetailView.as_view(), name="trend_mission_list"),
 ]

--- a/trend_missions/urls.py
+++ b/trend_missions/urls.py
@@ -4,5 +4,5 @@ from . import views
 urlpatterns = [
     path("create", views.PostTrendMissionView.as_view(), name="post_trend_mission"),
     path("<int:pk>", views.TrendMissionListView.as_view(), name="trend_mission_list"),
-    path("about/<int:pk>", views.TrendMissionDetailView.as_view(), name="trend_mission_list"),
+    path("about/<int:pk>", views.TrendMissionDetailView.as_view(), name="trend_mission_detail"),
 ]

--- a/trend_missions/views.py
+++ b/trend_missions/views.py
@@ -12,7 +12,6 @@ from trends.models import TrendItem, Trend
 from accounts.models import User
 
 
-# Create your views here.
 class PostTrendMissionView(GenericAPIView):
     # 트렌드 인증 미션 생성
     def post(self, request):
@@ -50,3 +49,20 @@ class TrendMissionListView(GenericAPIView):
         serializer = TrendMissionsSerializer(trend_mission, many=True)
         return Response(serializer.data, status=200)
     
+
+class TrendMissionDetailView(GenericAPIView):
+    # 트레드 미션 상세 조회
+    def get(self, request, pk):
+
+        # 트렌드 미션 존재 여부 확인
+        if not TrendMission.objects.filter(pk=pk).exists():
+            return Response("존재하지 않는 트렌드 미션입니다.", status=404)
+
+        trend_mission = TrendMission.objects.get(pk=pk)
+        serializer = TrendMissionsSerializer(trend_mission)
+
+        # 트렌드 미션에 해당하는 유저의 트렌드 아이템 리스트 조회
+        user_trend_item_list = UserTrendItem.objects.filter(trend_mission_id=pk)
+        result = serializer.data
+        result["trend_item_list"] = user_trend_item_list.values()
+        return Response(result, status=200)


### PR DESCRIPTION
## 개요
trend mission 상세 조회 기능 구현

- 수정사항
  - Meta 클래스의 fields = '__all__'를 각 필드명으로 수정
  
- 기능
  - 트렌드 미션의 pk값으로 트렌드 미션 상세 조회 기능
  - 트렌드 미션에 대한 정보와 해당하는 유저의 트렌드 아이템들 같이 반환함

- 비고
  - 모든 테스트 통과

## PR 유형

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정


## PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.

resolved: #17 