### PR TITLE
✨ Feature: 트렌드 미션 페이지 댓글&대댓글 API

### DIFF
--- a/hotcake/urls.py
+++ b/hotcake/urls.py
@@ -19,5 +19,6 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('',include('accounts.urls'))
+    path('',include('accounts.urls')),
+    path('trend-missions/',include('trend_missions.urls')),
 ]

--- a/trend_missions/models.py
+++ b/trend_missions/models.py
@@ -37,6 +37,9 @@ class Comment(models.Model):
         "self", on_delete=models.CASCADE, blank=True, null=True
     )
 
+    def __str__(self):
+        return self.user.nickname + "의 " + self.trend_mission.trend.name + "댓글" + str(self.id)
+
 
 class UserTrendItem(models.Model):
     id = models.AutoField(primary_key=True)

--- a/trend_missions/serializers.py
+++ b/trend_missions/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import TrendMission, UserTrendItem, Stamp
+from .models import TrendMission, UserTrendItem, Stamp, Comment
 
 
 class PostTrendMissionsSerializer(serializers.ModelSerializer):
@@ -45,3 +45,8 @@ class StampSerializer(serializers.ModelSerializer):
     class Meta:
         model = Stamp
         fields = ["user", "trend_mission", "created_at"]
+
+class CommentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = ["user", "trend_mission", "content", "created_at", "updated_at", "parent_comment"]

--- a/trend_missions/tests.py
+++ b/trend_missions/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase, Client
 from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 from django.contrib.auth.models import User
-from .models import TrendMission, TrendItem, UserTrendItem, Stamp
+from .models import TrendMission, TrendItem, UserTrendItem, Stamp, Comment
 from accounts.models import User
 from trends.models import Trend
 
@@ -213,3 +213,75 @@ class CommentTest(TestCase):
         )
         self.assertEqual(response.status_code, 404)
 
+
+# 트렌드 미션 페이지 대댓글 테스트
+class CommentReplyTest(TestCase):
+    """트렌드 미션 페이지 대댓글 테스트"""
+    def setUp(self):
+        # 테스트를 위한 유저 생성
+        # 테스트를 위한 유저 생성
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            "kakao",
+            "123456789",
+            "test@gmail.com",
+            "testuser",
+            "testprofileimg",
+            "testbio",
+            "123456789@"
+
+        )
+        # 테스트 클라이언트 인증 방식
+        self.client.force_authenticate(user=self.user)
+
+        # 테스트를 위한 트렌드 생성
+        self.trend = Trend.objects.create(
+            name="test-trend1",
+        )
+
+        # 사용자 트렌드 미션 생성
+        self.trend_mission = TrendMission.objects.create(
+            user=self.user,
+            trend=self.trend,
+        )
+
+        # 댓글 생성
+        self.comment = Comment.objects.create(
+            user=self.user,
+            trend_mission=self.trend_mission,
+            content="test-comment",
+        )
+
+    # 대댓글 성공 테스트
+    def test_comment_reply_success(self):
+        # 대댓글 생성
+        response = self.client.post(
+            f"/trend-missions/comments/{self.comment.id}/replies/{self.user.id}",
+            {
+                "content": "test-reply",
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+    
+    """대댓글 실패 테스트"""
+    # 대댓글 실패 테스트 - 없는 댓글
+    def test_comment_reply_fail(self):
+        # 대댓글 생성
+        response = self.client.post(
+            f"/trend-missions/comments/-2/replies/{self.user.id}",
+            {
+                "content": "test-reply",
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+    
+    # 대댓글 실패 테스트 - 없는 사용자의 요청
+    def test_comment_reply_fail2(self):
+        # 대댓글 생성
+        response = self.client.post(
+            f"/trend-missions/comments/{self.comment.id}/replies/-2",
+            {
+                "content": "test-reply",
+            }
+        )
+        self.assertEqual(response.status_code, 404)

--- a/trend_missions/tests.py
+++ b/trend_missions/tests.py
@@ -1,4 +1,5 @@
-from django.test import TestCase, Client, RequestFactory
+from django.test import TestCase, Client
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 from django.contrib.auth.models import User
 from .models import TrendMission, TrendItem, UserTrendItem, Stamp
 from accounts.models import User
@@ -9,119 +10,24 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http.multipartparser import MultiPartParser
 
 
-class CreateTrendMissionAPITestCase(TestCase):
-    """트렌드 미션 생성 테스트"""
-
+# 트렌드 미션 페이지 댓글 테스트
+class CommentTest(TestCase):
+    """트렌드 미션 페이지 댓글 테스트"""
     def setUp(self):
         # 테스트를 위한 유저 생성
-        self.client = Client()
+        self.client = APIClient()
         self.user = User.objects.create_user(
-            "testuser", "testemail@test.com", "123456789@"
+            "kakao",
+            "123456789",
+            "test@gmail.com",
+            "testuser",
+            "testprofileimg",
+            "testbio",
+            "123456789@"
+
         )
-
-
-class StampDetailAPITest(TestCase):
-    """스탬프 상세 조회 테스트"""
-        # 테스트를 위한 트렌드 아이템 생성
-        self.trend_item1 = TrendItem.objects.create(
-            title="test-trend-item1",
-            content="test-trend-item-content1",
-            image="test-trend-item-image1",
-        )
-        self.trend_item1.trend.set([self.trend])
-
-        self.trend_item2 = TrendItem.objects.create(
-            title="test-trend-item2",
-            content="test-trend-item-content2",
-            image="test-trend-item-image2",
-        )
-        self.trend_item2.trend.set([self.trend])
-
-        self.trend_item3 = TrendItem.objects.create(
-            title="test-trend-item3",
-            content="test-trend-item-content3",
-            image="test-trend-item-image3",
-        )
-        self.trend_item3.trend.set([self.trend])
-
-    # 정상 작동 테스트
-    def test_createTrendMission_success(self):
-        response = self.client.post(
-            "/trend-missions/create",
-            {"user": self.user.id, "trend": self.trend.id},
-        )
-        self.assertEqual(response.status_code, 200)
-
-    # 비정상 작동 테스트
-    # 이미 생성된 경우 400 에러
-    def test_already_createTrendMission_fail(self):
-        # 트렌드 미션 미리 생성
-        TrendMission.objects.create(
-            user=self.user,
-            trend=self.trend,
-        )
-
-        # 이미 생성된 트렌드 미션 생성 요청
-        response = self.client.post(
-            "/trend-missions/create",
-            {"user": self.user.id, "trend": self.trend.id},
-        )
-        self.assertEqual(response.status_code, 404)
-
-
-# http://127.0.0.1:8000/trend-missions/{userid}
-class TrendMissionListAPITestCase(TestCase):
-    """특정 사용자의 미션 리스트 조회 테스트"""
-
-    def setUp(self):
-        # 테스트를 위한 유저 생성
-        self.client = Client()
-        self.user = User.objects.create_user(
-            "testuser", "testemail@test.com", "123456789@"
-        )
-
-        # 테스트를 위한 트렌드 생성
-        self.trend1 = Trend.objects.create(
-            name="test-trend1",
-        )
-
-        self.trend2 = Trend.objects.create(
-            name="test-trend2",
-        )
-
-    # 정상 작동 테스트
-    def test_getTrendMissionList_success(self):
-        # 트렌드 미션 미리 생성
-        TrendMission.objects.create(
-            user=self.user,
-            trend=self.trend1,
-        )
-
-        TrendMission.objects.create(
-            user=self.user,
-            trend=self.trend1,
-        )
-        response = self.client.get(f"/trend-missions/{self.user.id}")
-
-        self.assertEqual(response.status_code, 200)
-
-    # 비정상 작동 테스트
-    # 정확하게는 비정상이 아닌, 트렌드 미션을 생성하지 않은 경우 빈 배열 반환
-
-    def test_getTrendMissionList_not_have_list(self):
-        response = self.client.get(f"/trend-missions/{self.user.id}")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, [])
-
-
-class TrendMissionDetailAPITestCase(TestCase):
-    """트렌드 미션 상세 조회 테스트"""
-    def setUp(self):
-        # 테스트를 위한 유저 생성
-        self.client = Client()
-        self.user = User.objects.create_user(
-            "testuser", "testemail@test.com", "123456789@"
-        )
+        # 테스트 클라이언트 인증 방식
+        self.client.force_authenticate(user=self.user)
 
         # 테스트를 위한 트렌드 생성
         self.trend = Trend.objects.create(
@@ -134,190 +40,24 @@ class TrendMissionDetailAPITestCase(TestCase):
             trend=self.trend,
         )
 
-
-        # 스탬프 생성
-        self.stamp = Stamp.objects.create(
-            user=self.user,
-            trend_mission=self.trend_mission,
+    # 댓글 성공 테스트
+    def test_comment_success(self):
+        # 댓글 생성
+        response = self.client.post(
+            f"/trend-missions/1/comments/{self.user.id}",
+            {
+                "content": "test-comment",
+            }
         )
-
-    # 스탬프 상세 조회 성공 테스트
-    def test_StampDetail(self):
-        response = self.client.get(f"/trend-missions/users/stamp/{self.user.id}")
         self.assertEqual(response.status_code, 200)
-
-    # 스탬프 리스트 조회 실패 테스트
-    def test_StampList_fail(self):
-        response = self.client.get(f"/trend-missions/users/stamp/-2")
-        self.assertEqual(response.status_code, 404)
-    # 트렌드 미션 상세 조회 성공 테스트
-    def test_TrendMissions_detail(self):
-        response = self.client.get(f"/trend-missions/about/{self.trend_mission.id}")
-        self.assertEqual(response.status_code, 200)
-
-    # 트렌드 미션 상세 조회 실패 테스트
-    def test_TrendMissions_detail_fail(self):
-        response = self.client.get(f"/trend-missions/about/-2")
-        self.assertEqual(response.status_code, 404)
-
-
-"""
-# 트렌드 미션 아이템 업데이트 테스트
-    # 트렌드 미션 아이템 업데이트 테스트
-    # 데이터 형태때문에 테스트가 계속 실패
-    # 직접 테스트로 대체
     
-"""
-
-
-class TrendMissionCompleteAPITestCase(TestCase):
-    """트렌드 미션 완료 테스트"""
-
-    def setUp(self):
-        # 테스트를 위한 유저 생성
-        self.client = Client()
-        self.user = User.objects.create_user(
-            "testuser", "testemail@test.com", "123456789@"
+    # 댓글 생성 실패 테스트 (없는 트렌드 미션 페이지)
+    def test_comment_fail(self):
+        # 댓글 생성
+        response = self.client.post(
+            f"/trend-missions/-2/comments/{self.user.id}",
+            {
+                "content": "test-comment",
+            }
         )
-
-        # 테스트를 위한 트렌드 생성
-        self.trend = Trend.objects.create(
-            name="test-trend1",
-        )
-
-        # 테스트를 위한 트렌드 아이템 생성
-        self.trend_item1 = TrendItem.objects.create(
-            title="test-trend-item1",
-            content="test-trend-item-content1",
-            image="test-trend-item-image1",
-        )
-        self.trend_item1.trend.set([self.trend])
-
-        self.trend_item2 = TrendItem.objects.create(
-            title="test-trend-item2",
-            content="test-trend-item-content2",
-            image="test-trend-item-image2",
-        )
-        self.trend_item2.trend.set([self.trend])
-
-        self.trend_item3 = TrendItem.objects.create(
-            title="test-trend-item3",
-            content="test-trend-item-content3",
-            image="test-trend-item-image3",
-        )
-        self.trend_item3.trend.set([self.trend])
-
-        # 사용자 트렌드 미션 생성
-        self.trend_mission = TrendMission.objects.create(
-            user=self.user,
-            trend=self.trend,
-        )
-
-    # 트렌드 미션 완료 성공 테스트
-    def test_TrendMissions_complete(self):
-        # 사용자 트렌드 미션 아이템 생성
-        self.trend_mission_item = UserTrendItem.objects.create(
-            user=self.user,
-            trend_mission=self.trend_mission,
-            trend_item=self.trend_item1,
-            is_certificated=True,  # 트렌드 미션 완료 처리
-        )
-
-        response = self.client.patch(
-            f"/trend-missions/{self.trend_mission.id}/complete",
-            {"user": self.user.id},
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, 200)
-
-    # 트렌드 미션 완료 실패(아직 미션 완료 x) 테스트
-    def test_TrendMissions_complete_fail(self):
-        # 사용자 트렌드 미션 아이템 생성
-        self.trend_mission_item = UserTrendItem.objects.create(
-            user=self.user,
-            trend_mission=self.trend_mission,
-            trend_item=self.trend_item1,
-            is_certificated=False,  # 아직 모든 인증 완료 x
-        )
-
-        response = self.client.patch(
-            f"/trend-missions/{self.trend_mission.id}/complete",
-            {"user": self.user.id},
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, 202)
-
-
-class StampListAPITestCase(TestCase):
-    """스탬프 리스트 조회 테스트"""
-
-    def setUp(self):
-        # 테스트를 위한 유저 생성
-        self.client = Client()
-        self.user = User.objects.create_user(
-            "testuser", "testemail@test.com", "123456789@"
-        )
-
-        # 테스트를 위한 트렌드 생성
-        self.trend = Trend.objects.create(
-            name="test-trend1",
-        )
-
-        # 사용자 트렌드 미션 생성
-        self.trend_mission = TrendMission.objects.create(
-            user=self.user,
-            trend=self.trend,
-        )
-
-        # 스탬프 생성
-        self.stamp = Stamp.objects.create(
-            user=self.user,
-            trend_mission=self.trend_mission,
-        )
-
-    # 스탬프 리스트 조회 성공 테스트
-    def test_StampList(self):
-        response = self.client.get(f"/trend-missions/users/{self.user.id}/stamp")
-        self.assertEqual(response.status_code, 200)
-
-    # 스탬프 리스트 조회 실패 테스트
-    def test_StampList_fail(self):
-        response = self.client.get(f"/trend-missions/users/-2/stamp")
-        self.assertEqual(response.status_code, 404)
-        
-        
-class StampDetailAPITest(TestCase):
-    """스탬프 상세 조회 테스트"""
-    def setUp(self):
-        # 테스트를 위한 유저 생성
-        self.client = Client()
-        self.user = User.objects.create_user(
-            "testuser", "testemail@test.com", "123456789@"
-        )
-
-        # 테스트를 위한 트렌드 생성
-        self.trend = Trend.objects.create(
-            name="test-trend1",
-        )
-
-        # 사용자 트렌드 미션 생성
-        self.trend_mission = TrendMission.objects.create(
-            user=self.user,
-            trend=self.trend,
-        )
-
-        # 스탬프 생성
-        self.stamp = Stamp.objects.create(
-            user=self.user,
-            trend_mission=self.trend_mission,
-        )
-
-    # 스탬프 상세 조회 성공 테스트
-    def test_StampDetail(self):
-        response = self.client.get(f"/trend-missions/users/stamp/{self.user.id}")
-        self.assertEqual(response.status_code, 200)
-
-    # 스탬프 리스트 조회 실패 테스트
-    def test_StampList_fail(self):
-        response = self.client.get(f"/trend-missions/users/stamp/-2")
         self.assertEqual(response.status_code, 404)

--- a/trend_missions/tests.py
+++ b/trend_missions/tests.py
@@ -61,3 +61,86 @@ class CommentTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 404)
+
+    # 댓글 수정 성공 테스트
+    def test_comment_update_success(self):
+        # 댓글 생성
+        response = self.client.post(
+            f"/trend-missions/1/comments/{self.user.id}",
+            {
+                "content": "test-comment",
+            }
+        )
+        # 댓글 수정
+        response = self.client.patch(
+            f"/trend-missions/comments/1/{self.user.id}",
+            {
+                "content": "test-comment-update",
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+    
+    # 댓글 수정 실패 테스트 - 없는 댓글
+    def test_comment_update_fail(self):
+        # 댓글 생성
+        response = self.client.post(
+            f"/trend-missions/1/comments/{self.user.id}",
+            {
+                "content": "test-comment",
+            }
+        )
+        # 댓글 수정
+        response = self.client.patch(
+            f"/trend-missions/comments/-2/{self.user.id}",
+            {
+                "content": "test-comment-update",
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+
+    # 댓글 수정 실패 테스트 - 없는 사용자의 요청
+    def test_comment_update_fail2(self):
+        # 댓글 생성
+        response = self.client.post(
+            f"/trend-missions/1/comments/{self.user.id}",
+            {
+                "content": "test-comment",
+            }
+        )
+        # 댓글 수정
+        response = self.client.patch(
+            f"/trend-missions/comments/1/-2",
+            {
+                "content": "test-comment-update",
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+    
+    # 댓글 수정 실패 테스트 - 댓글 작성자가 아닌 사용자의 요청
+    def test_comment_update_fail3(self):
+        # 다른 사용자 생성
+        user2 = User.objects.create_user(
+            "kakao2",
+            "1234567892",
+            "test@gmail.com2",
+            "testuser2",
+            "testprofileimg2",
+            "testbio2",
+            "123456789@2"
+        )
+        # 댓글 생성
+        response = self.client.post(
+            f"/trend-missions/1/comments/{self.user.id}",
+            {
+                "content": "test-comment",
+            }
+        )
+        # 댓글 수정
+        response = self.client.patch(
+            f"/trend-missions/comments/1/{user2.id}",
+            {
+                "content": "test-comment-update",
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+

--- a/trend_missions/tests.py
+++ b/trend_missions/tests.py
@@ -252,7 +252,7 @@ class CommentReplyTest(TestCase):
             content="test-comment",
         )
 
-    # 대댓글 성공 테스트
+    # 대댓글 작성 성공 테스트
     def test_comment_reply_success(self):
         # 대댓글 생성
         response = self.client.post(
@@ -263,8 +263,8 @@ class CommentReplyTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
     
-    """대댓글 실패 테스트"""
-    # 대댓글 실패 테스트 - 없는 댓글
+    """대댓글 작성 실패 테스트"""
+    # 대댓글 작성 실패 테스트 - 없는 댓글
     def test_comment_reply_fail(self):
         # 대댓글 생성
         response = self.client.post(
@@ -275,7 +275,7 @@ class CommentReplyTest(TestCase):
         )
         self.assertEqual(response.status_code, 404)
     
-    # 대댓글 실패 테스트 - 없는 사용자의 요청
+    # 대댓글 작성 실패 테스트 - 없는 사용자의 요청
     def test_comment_reply_fail2(self):
         # 대댓글 생성
         response = self.client.post(
@@ -285,3 +285,99 @@ class CommentReplyTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 404)
+    
+    """대댓글 수정 테스트"""
+    # 대댓글 수정 성공 테스트
+    def test_comment_reply_update_success(self):
+        # 대댓글 생성
+        response = self.client.post(
+            f"/trend-missions/comments/{self.comment.id}/replies/{self.user.id}",
+            {
+                "content": "test-reply",
+            }
+        )
+        # 대댓글 생성
+        self.comment_reply = Comment.objects.create(
+            user=self.user,
+            trend_mission=self.trend_mission,
+            content="test-reply",
+            parent_comment=self.comment,
+        )
+        # 대댓글 수정
+        response = self.client.patch(
+            f"/trend-missions/comments/{self.comment_reply.id}/replies/{self.user.id}",
+            {
+                "content": "test-reply-update",
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+
+    # 대댓글 수정 실패 테스트 - 작성자가 다름
+    def test_comment_reply_update_fail(self):
+        # 다른 사용자 생성
+        user2 = User.objects.create_user(
+            "kakao2",
+            "1234567892",
+            "test@gmail.com2",
+            "testuser2",
+            "testprofileimg2",
+            "testbio2",
+            "123456789@2"
+        )
+        # 대댓글 생성
+        self.comment_reply = Comment.objects.create(
+            user=self.user,
+            trend_mission=self.trend_mission,
+            content="test-reply",
+            parent_comment=self.comment,
+        )
+        # 대댓글 수정
+        response = self.client.patch(
+            f"/trend-missions/comments/{self.comment_reply.id}/replies/-2",
+            {
+                "content": "test-reply-update",
+            }
+        )
+        self.assertEqual(response.status_code, 404)
+    
+    """대댓글 삭제 테스트"""
+    # 대댓글 삭제 성공 테스트
+    def test_comment_reply_delete_success(self):
+        # 대댓글 생성
+        self.comment_reply = Comment.objects.create(
+            user=self.user,
+            trend_mission=self.trend_mission,
+            content="test-reply",
+            parent_comment=self.comment,
+        )
+        # 대댓글 삭제
+        response = self.client.delete(
+            f"/trend-missions/comments/{self.comment_reply.id}/replies/{self.user.id}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+    # 대댓글 삭제 실패 테스트 - 작성자가 다름
+    def test_comment_reply_delete_fail(self):
+        # 다른 사용자 생성
+        user2 = User.objects.create_user(
+            "kakao2",
+            "1234567892",
+            "test@gmail.com2",
+            "testuser2",
+            "testprofileimg2",
+            "testbio2",
+            "123456789@2"
+        )
+        # 대댓글 생성
+        self.comment_reply = Comment.objects.create(
+            user=self.user,
+            trend_mission=self.trend_mission,
+            content="test-reply",
+            parent_comment=self.comment,
+        )
+        # 대댓글 삭제
+        response = self.client.delete(
+            f"/trend-missions/comments/{self.comment_reply.id}/replies/-2",
+        )
+        self.assertEqual(response.status_code, 404)
+        

--- a/trend_missions/tests.py
+++ b/trend_missions/tests.py
@@ -143,4 +143,73 @@ class CommentTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 404)
+    # 댓글 삭제
+    def test_comment_delete_success(self):
+        # 댓글 생성
+        response = self.client.post(
+            f"/trend-missions/1/comments/{self.user.id}",
+            {
+                "content": "test-comment",
+            }
+        )
+        # 댓글 삭제
+        response = self.client.delete(
+            f"/trend-missions/comments/1/{self.user.id}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+    # 댓글 삭제 실패 테스트 - 없는 댓글
+    def test_comment_delete_fail(self):
+        # 댓글 생성
+        response = self.client.post(
+            f"/trend-missions/1/comments/{self.user.id}",
+            {
+                "content": "test-comment",
+            }
+        )
+        # 댓글 삭제
+        response = self.client.delete(
+            f"/trend-missions/comments/-2/{self.user.id}",
+        )
+        self.assertEqual(response.status_code, 404)
+    
+    # 댓글 삭제 실패 테스트 - 없는 사용자의 요청
+    def test_comment_delete_fail2(self):
+        # 댓글 생성
+        response = self.client.post(
+            f"/trend-missions/1/comments/{self.user.id}",
+            {
+                "content": "test-comment",
+            }
+        )
+        # 댓글 삭제
+        response = self.client.delete(
+            f"/trend-missions/comments/1/-2",
+        )
+        self.assertEqual(response.status_code, 404)
+    
+    # 댓글 삭제 실패 테스트 - 댓글 작성자가 아닌 사용자의 요청
+    def test_comment_delete_fail3(self):
+        # 다른 사용자 생성
+        user2 = User.objects.create_user(
+            "kakao2",
+            "1234567892",
+            "test@gmail.com2",
+            "testuser2",
+            "testprofileimg2",
+            "testbio2",
+            "123456789@2"
+        )
+        # 댓글 생성
+        response = self.client.post(
+            f"/trend-missions/1/comments/{self.user.id}",
+            {
+                "content": "test-comment",
+            }
+        )
+        # 댓글 삭제
+        response = self.client.delete(
+            f"/trend-missions/comments/1/{user2.id}",
+        )
+        self.assertEqual(response.status_code, 404)
 

--- a/trend_missions/urls.py
+++ b/trend_missions/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path("about/<int:pk>", views.TrendMissionDetailView.as_view(), name="trend_mission_detail"),
     path("mission-item/<int:pk>/edit", views.TrendMissionItemUpdateView.as_view(), name="trend_mission_item_update"),
     path("<int:pk>/complete", views.CheckMissionCompleteView.as_view(), name="trend_mission_complete"),
-    path("users/stamp/<int:pk>", views.StampDetailView.as_view(), name="stamp_detail")
+    path("users/stamp/<int:pk>", views.StampDetailView.as_view(), name="stamp_detail"),
     path("users/<int:user_id>/stamp", views.StampListView.as_view(), name="stamp_list"),
+    path("<int:trend_mission_id>/comments/<int:user_id>", views.CommentView.as_view(), name="trend_mission_comment")
 ]

--- a/trend_missions/urls.py
+++ b/trend_missions/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path("<int:pk>/complete", views.CheckMissionCompleteView.as_view(), name="trend_mission_complete"),
     path("users/stamp/<int:pk>", views.StampDetailView.as_view(), name="stamp_detail"),
     path("users/<int:user_id>/stamp", views.StampListView.as_view(), name="stamp_list"),
-    path("<int:trend_mission_id>/comments/<int:user_id>", views.CommentView.as_view(), name="trend_mission_comment")
+    path("<int:trend_mission_id>/comments/<int:user_id>", views.CommentView.as_view(), name="trend_mission_comment"),
+    path("comments/<int:comment_id>/<int:user_id>", views.CommentUpdateView.as_view(), name="trend_mission_comment_update"),
 ]

--- a/trend_missions/urls.py
+++ b/trend_missions/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path("users/<int:user_id>/stamp", views.StampListView.as_view(), name="stamp_list"),
     path("<int:trend_mission_id>/comments/<int:user_id>", views.CommentView.as_view(), name="trend_mission_comment"),
     path("comments/<int:comment_id>/<int:user_id>", views.CommentUpdateView.as_view(), name="trend_mission_comment_update"),
+    path("comments/<int:comment_id>/replies/<int:user_id>", views.CommentReply.as_view(), name="trend_mission_comment_reply"),
 ]

--- a/trend_missions/views.py
+++ b/trend_missions/views.py
@@ -209,3 +209,20 @@ class CommentUpdateView(GenericAPIView):
         comment.save()
         serializer = CommentSerializer(comment)
         return Response(serializer.data, status=200)
+    
+    """댓글 삭제"""
+    def delete(self, request, comment_id, user_id):
+        comment = Comment.objects.get(pk=comment_id)
+        # 댓글 존재 여부 확인
+        if not comment:
+            return Response("존재하지 않는 댓글입니다.", status=404)
+        user = User.objects.get(pk=user_id)
+        # 사용자 존재 여부 확인
+        if not user:
+            return Response("존재하지 않는 사용자입니다.", status=404)
+        # 댓글 작성자 확인
+        if comment.user != user:
+            return Response("댓글 작성자가 아니라 삭제 권한이 없습니다.", status=404)
+        # 댓글 삭제
+        comment.delete()
+        return Response("댓글이 삭제되었습니다.", status=200)

--- a/trend_missions/views.py
+++ b/trend_missions/views.py
@@ -10,10 +10,11 @@ from .serializers import (
     UserTrendItemSerializer,
     UserTrendItemUpdateSerializer,
     StampSerializer,
+    CommentSerializer
 )
 
 # models
-from .models import TrendMission, UserTrendItem, Stamp
+from .models import TrendMission, UserTrendItem, Stamp, Comment
 from trends.models import TrendItem, Trend
 from accounts.models import User
 
@@ -153,10 +154,9 @@ class StampDetailView(GenericAPIView):
             trend_item_list, many=True
         ).data
         return Response(result, status=200)
-      
+    
 class StampListView(GenericAPIView):
     """스탬프 리스트 조회"""
-
     def get(self, request, user_id):
         # 사용자 존재 여부 확인
         if not User.objects.filter(pk=user_id).exists():
@@ -165,3 +165,27 @@ class StampListView(GenericAPIView):
         stamp_list = Stamp.objects.filter(user=user_id)
         serializer = StampSerializer(stamp_list, many=True)
         return Response(serializer.data, status=200)
+
+
+class CommentView(GenericAPIView):
+    """댓글 작성"""
+    def post(self, request, trend_mission_id, user_id):
+        trend_mission = TrendMission.objects.get(pk=trend_mission_id)
+        # 트렌드 미션 존재 여부 확인
+        if not trend_mission:
+            return Response("존재하지 않는 트렌드 미션입니다.", status=404)
+        user = User.objects.get(pk=user_id)
+        # 사용자 존재 여부 확인 
+        if not user:
+            return Response("존재하지 않는 사용자입니다.", status=404)
+
+        # 댓글 작성
+        content= request.data["content"]
+        comment = Comment.objects.create(
+            user=user,
+            trend_mission=trend_mission,
+            content=content,
+        )
+        serializer = CommentSerializer(comment)
+        return Response(serializer.data, status=200)
+    

--- a/trend_missions/views.py
+++ b/trend_missions/views.py
@@ -188,4 +188,24 @@ class CommentView(GenericAPIView):
         )
         serializer = CommentSerializer(comment)
         return Response(serializer.data, status=200)
-    
+
+class CommentUpdateView(GenericAPIView):
+    """댓글 수정"""
+    def patch(self, request, comment_id, user_id):
+        comment = Comment.objects.get(pk=comment_id)
+        # 댓글 존재 여부 확인
+        if not comment:
+            return Response("존재하지 않는 댓글입니다.", status=404)
+        user = User.objects.get(pk=user_id)
+        # 사용자 존재 여부 확인
+        if not user:
+            return Response("존재하지 않는 사용자입니다.", status=404)
+        # 댓글 작성자 확인
+        if comment.user != user:
+            return Response("댓글 작성자가 아니라 수정 권한이 없습니다.", status=404)
+        # 댓글 수정
+        content = request.data["content"]
+        comment.content = content
+        comment.save()
+        serializer = CommentSerializer(comment)
+        return Response(serializer.data, status=200)

--- a/trend_missions/views.py
+++ b/trend_missions/views.py
@@ -250,4 +250,40 @@ class CommentReply(GenericAPIView):
         serializer = CommentSerializer(reply)
         return Response(serializer.data, status=200)
     
+    """대댓글 수정"""
+    def patch(self, request, comment_id, user_id):
+        reply = Comment.objects.get(pk=comment_id)
+        # 대댓글 존재 여부 확인
+        if not reply:
+            return Response("존재하지 않는 대댓글입니다.", status=404)
+        user = User.objects.get(pk=user_id)
+        # 사용자 존재 여부 확인
+        if not user:
+            return Response("존재하지 않는 사용자입니다.", status=404)
+        # 대댓글 작성자 확인
+        if reply.user != user:
+            return Response("대댓글 작성자가 아니라 수정 권한이 없습니다.", status=404)
+        # 대댓글 수정
+        content = request.data["content"]
+        reply.content = content
+        reply.save()
+        serializer = CommentSerializer(reply)
+        return Response(serializer.data, status=200)
+
+    """대댓글 삭제"""
+    def delete(self, request, comment_id, user_id):
+        reply = Comment.objects.get(pk=comment_id)
+        # 대댓글 존재 여부 확인
+        if not reply:
+            return Response("존재하지 않는 대댓글입니다.", status=404)
+        user = User.objects.get(pk=user_id)
+        # 사용자 존재 여부 확인
+        if not user:
+            return Response("존재하지 않는 사용자입니다.", status=404)
+        # 대댓글 작성자 확인
+        if reply.user != user:
+            return Response("대댓글 작성자가 아니라 삭제 권한이 없습니다.", status=404)
+        # 대댓글 삭제
+        reply.delete()
+        return Response("대댓글이 삭제되었습니다.", status=200)
     

--- a/trend_missions/views.py
+++ b/trend_missions/views.py
@@ -226,3 +226,28 @@ class CommentUpdateView(GenericAPIView):
         # 댓글 삭제
         comment.delete()
         return Response("댓글이 삭제되었습니다.", status=200)
+    
+# 대댓글 
+class CommentReply(GenericAPIView):
+    """대댓글 작성"""
+    def post(self, request, comment_id, user_id):
+        comment = Comment.objects.get(pk=comment_id)
+        # 댓글 존재 여부 확인
+        if not comment:
+            return Response("존재하지 않는 댓글입니다.", status=404)
+        user = User.objects.get(pk=user_id)
+        # 사용자 존재 여부 확인
+        if not user:
+            return Response("존재하지 않는 사용자입니다.", status=404)
+        # 대댓글 작성
+        content = request.data["content"]
+        reply = Comment.objects.create(
+            user=user,
+            trend_mission=comment.trend_mission,
+            content=content,
+            parent_comment=comment,
+        )
+        serializer = CommentSerializer(reply)
+        return Response(serializer.data, status=200)
+    
+    


### PR DESCRIPTION
## 개요

✨ Feature: 트렌드 미션 페이지 댓글 작성
- 기능구현
  - 트렌드 미션 페이지로 댓글 작성 요청 개발
  - 페이지 id, 사용자 id를 url에 담고, content에 작성할 내용을 담아 전송

- 비고
  - 테스트 완료

✨ Feature: 트렌드 미션 페이지 댓글 수정
- 기능 구현
  - url에 페이지, 사용자 id를 넣고 수정할 내용을 JSON에 담아 전달
  - 요청 확인
    - 페이지가 존재하는지
    - 사용자가 존재하는지
    - 작성자와 사용자가 일치하는지 순서대로 확인

- 비고
  - 테스트 수행 완료
  
✨ Feature: 트렌드 미션 페이지 댓글 삭제
- 기능 구현
  - 댓글 삭제
    - 댓글 확인
    - 사용자 확인
    - 작성자와 사용자 일치 확인
    - 삭제처리

- 비고
  - 테스트 수행 완료

==============================================================================

✨ Feature: 대댓글 작성 기능 구현
- 기능 구현
  - url에 작성자와 대댓글을 작성할 댓글의 id값을 담아 요청
  - 댓글이 존재하지 않다면 에러 반환
  - 사용자가 없는 사용자일 경우 에러 반환

- 비고
  - 대댓글 작성 테스트 수행 완료


✨ Feature: 트렌드 미션 대댓글 수정 & 삭제 기능
- 기능 구현
  - 수정은 Patch, 삭제는 Delete 요청으로 처리
  - 각 기능 예외처리
    - 댓글이 있는지
    - 사용자가 존재하는지
    - 작성자와 요청하는 사용자가 일치하는지
    - 요청 처리

- 비고
  - 테스트 수행 완료




 Resolves: #40 #41

## PR 유형
- [x] 새로운 기능 추가
- [x] 테스트 추가, 테스트 리팩토링


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
