### PR TITLE
:sparkles: Feat: 카카오 소셜 로그인 및 서비스 로그아웃 처리

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import authenticate
-from rest_framework import serializers
+from rest_framework import serializers, exceptions
+from rest_framework_simplejwt.tokens import RefreshToken, TokenError
 
 from .models import User
 
@@ -15,7 +16,7 @@ class UserSerializer(serializers.Serializer):
     class Meta:
         model = User
         fields = ["social_type", "social_id", "email", "nickname", "profile_img", "bio"]
-        read_only_fields = ('social_id', 'social_type', 'created_at', 'last_login')
+        read_only_fields = ("social_id", "social_type")
 
     def validate(self, data):
         user = authenticate(social_id=data.get("social_id"))
@@ -26,3 +27,24 @@ class UserSerializer(serializers.Serializer):
     def create(self, validated_data):
         user = User.objects.create(**validated_data)
         return user
+
+
+class LogoutSerializer(serializers.Serializer):
+    refresh_token = serializers.CharField()
+
+    def validate(self, data):
+        """토큰 유효 검증"""
+        try:
+            self.token = data["refresh_token"]
+        except:
+            raise serializers.ValidationError({"error": "Invalid Token"})
+
+        return data
+
+    def save(self, **kwargs):
+        """토큰을 블랙리스트에 추가"""
+        try:
+            RefreshToken(self.token).blacklist()
+
+        except TokenError as ex:
+            raise exceptions.AuthenticationFailed(ex)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,7 +1,13 @@
 from django.urls import path
-from accounts.views import KakaoLogin, KakaoCallback, KakaoLogin
+from accounts.views import KakaoLogin, KakaoCallback, KakaoLogout, KakaoLogoutCallback
 
 urlpatterns = [
     path("oauth/kakao/login/", KakaoLogin.as_view(), name="kakao_login"),
     path("oauth/kakao/callback/", KakaoCallback.as_view(), name="kakao_callback"),
+    path("oauth/kakao/logout/", KakaoLogout.as_view(), name="kakao_logout"),
+    path(
+        "oauth/kakao/logout/callback/",
+        KakaoLogoutCallback.as_view(),
+        name="kakao_logout_callback",
+    ),
 ]


### PR DESCRIPTION
## 개요
- 기능
  - 카카오계정과 함께 로그아웃 추가
  - 카카오계정 로그아웃 후, 핫케이크 서비스의 refresh_token을 블랙리스트에 추가
  - 완료되면 200 응답

- 비고
  - .env에 kakao-logout-redirect-url 추가

Resolves: #32

## PR 유형
- [x] 새로운 기능 추가

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(기능에 대한 수동 테스트).

## 첨부
**카카오계정과 함께 로그아웃**
![image](https://github.com/HotCake-Tanghuru/HotCake-BE/assets/108624466/1fc994c8-7177-4040-b266-1c7011d71adc)
**핫케이크 서비스에서도 처리**
![image](https://github.com/HotCake-Tanghuru/HotCake-BE/assets/108624466/322f0436-b626-45f3-8c19-5766d3286046)
refresh_token을 POST하면 블랙리스트에 추가되고 200 응답