### PR TITLE
:sparkles: Feat: 카카오 연결끊기와 함께 회원탈퇴

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,5 +1,11 @@
 from django.urls import path
-from accounts.views import KakaoLogin, KakaoCallback, KakaoLogout, KakaoLogoutCallback
+from accounts.views import (
+    KakaoLogin,
+    KakaoCallback,
+    KakaoLogout,
+    KakaoLogoutCallback,
+    KakaoUnlink,
+)
 
 urlpatterns = [
     path("oauth/kakao/login/", KakaoLogin.as_view(), name="kakao_login"),
@@ -10,4 +16,5 @@ urlpatterns = [
         KakaoLogoutCallback.as_view(),
         name="kakao_logout_callback",
     ),
+    path("oauth/kakao/unlink/", KakaoUnlink.as_view(), name="kakao_unlink"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -161,7 +161,7 @@ class KakaoLogoutCallback(APIView):
 
 
 class KakaoUnlink(APIView):
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated]
 
     def delete(self, request):
         """카카오계정과 함께 회원탈퇴"""

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -22,6 +22,7 @@ kakao_login_uri = "https://kauth.kakao.com/oauth/authorize"
 kakao_token_uri = "https://kauth.kakao.com/oauth/token"
 kakao_user_uri = "https://kapi.kakao.com/v2/user/me"
 kakao_logout_uri = "https://kauth.kakao.com/oauth/logout"
+kakao_unlink_uri = "https://kapi.kakao.com/v1/user/unlink"
 
 
 class KakaoLogin(APIView):
@@ -71,6 +72,8 @@ class KakaoCallback(APIView):
                 {"message": "access_token이 없습니다."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        request.session["kakao_access_token"] = kakao_access_token
 
         kakao_access_token = f"Bearer {kakao_access_token}"
 
@@ -153,5 +156,36 @@ class KakaoLogoutCallback(APIView):
 
         serializer.is_valid(raise_exception=True)
         serializer.save()
+
+        return Response(status=status.HTTP_200_OK)
+
+
+class KakaoUnlink(APIView):
+    permission_classes = [AllowAny]
+
+    def delete(self, request):
+        """카카오계정과 함께 회원탈퇴"""
+        kakao_access_token = request.session.get("kakao_access_token")
+        if not kakao_access_token:
+            return Response(
+                {"message": "access_token이 없습니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        kakao_access_token = f"Bearer {kakao_access_token}"
+
+        # 카카오 연결끊기 요청
+        auth_headers = {
+            "Authorization": kakao_access_token,
+            "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+        }
+        unlinked_res = requests.post(kakao_unlink_uri, headers=auth_headers)
+        unlinked_json = unlinked_res.json()
+
+        social_type = "kakao"
+        social_id = f"{social_type}_{unlinked_json.get('id')}"
+
+        user = User.objects.get(social_id=social_id)
+        user.delete()
 
         return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
## 개요
회원탈퇴나 카카오 연결끊기를 원하는 사람은 두 가지 기능 모두 필요하다고 생각했습니다. 그래서 카카오 연결끊기와 회원탈퇴가 동시에 처리하도록 작성했습니다.

- 기능
  - 카카오 연결끊기 요청
  - 회원정보 삭제 (User모델 데이터 삭제)

- 테스트 결과
  -  카카오 연결 끊기와 유저 정보 삭제가 되는 것을 확인했습니다.
  - 회원 탈퇴후, 다시 회원가입 처리가 되는 것을 확인했습니다.

Resolves: #44

## PR 유형
- [x] 새로운 기능 추가

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(기능에 대한 수동 테스트)
