### PR TITLE
✨ Feat: 핫트렌드 API 구현

### DIFF
--- a/hotcake/urls.py
+++ b/hotcake/urls.py
@@ -19,5 +19,6 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('',include('accounts.urls'))
+    path('',include('accounts.urls')),
+    path('trends/',include('trends.urls')),
 ]

--- a/trends/serializers.py
+++ b/trends/serializers.py
@@ -1,0 +1,14 @@
+from rest_framework import serializers
+from .models import Trend
+
+
+class TrendSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Trend
+        fields = ["id", "name", "view_count", "created_at", "image"]
+
+
+class TrendItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Trend
+        fields = ["id", "trend", "title", "content", "image"]

--- a/trends/urls.py
+++ b/trends/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("", views.TrendView.as_view(), name="trends"),
+]

--- a/trends/views.py
+++ b/trends/views.py
@@ -1,3 +1,49 @@
 from django.shortcuts import render
+from rest_framework.generics import GenericAPIView
+from rest_framework.response import Response
 
-# Create your views here.
+from .models import Trend, TrendItem
+from accounts.models import User, Follow
+from trend_missions.models import UserTrendItem, TrendMission
+
+from .serializers import TrendSerializer, TrendItemSerializer
+from trend_missions.serializers import UserTrendItemSerializer
+from accounts.serializers import UserSerializer
+
+
+class TrendView(GenericAPIView):
+    """핫 트렌드 페이지 조회"""
+
+    def get(self, request):
+        # 트렌드 조회
+        trends = Trend.objects.all()
+        trend_serializer = TrendSerializer(trends, many=True)
+
+        # 팔로우한 사용자들의 트렌드 아이템 조회
+        user = request.user
+        follow_list = Follow.objects.filter(from_user=user)
+        user_trend_item_list = []
+
+        for follow in follow_list:
+            user_trend_items = UserTrendItem.objects.filter(user=follow.to_user)
+            user_trend_item_list.extend(user_trend_items)
+
+        result = {
+            "trends": trend_serializer.data,
+            "followed_trends": [],
+        }
+
+        # 팔로우한 유저 여부 확인
+        if not follow_list:
+            result["followed_trends"].append({"아직 팔로우한 친구가 없습니다."})
+
+        # 팔로우한 유저들의 트렌드 참여 여부 확인
+        elif not user_trend_item_list:
+            result["followed_trends"].append({"아직 트렌드에 참여 중인 친구가 없습니다."})
+        else:
+            trend_item_serializer = UserTrendItemSerializer(
+                user_trend_item_list, many=True
+            )
+            result["followed_trends"].extend(trend_item_serializer.data)
+
+        return Response(result, status=200)


### PR DESCRIPTION
## 개요
메인페이지에서 핫 트렌드가 조회될 수 있도록 했습니다. 또 팔로잉 한 친구들의 활동을 조회할 수 있도록 작성했습니다. 팔로잉 한 유저 중에 트렌드 미션에 참여 중인 유저가 있다면 유저의 트렌드 아이템을 조회할 수 있습니다.
- 기능
  - 핫 트렌드 조회
  - 참여 중인 친구들의 활동 조회

Resolves: #16

## PR 유형

- [x] 새로운 기능 추가

## PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(테스트 코드를 작성하지 못하여 직접 테스트 했습니다).

- 팔로우 한 유저가 없는 경우 핫 트렌드와 함께 "아직 팔로우한 친구가 없습니다."가 반환됩니다.
![팔로우한 친구 X](https://github.com/HotCake-Tanghuru/HotCake-BE/assets/142385695/cae573fe-cd45-4bc3-b965-9ead75f8381f)


- 팔로우 한 유저 중 트렌드 미션에 참여 중인 유저가 없는 경우 "아직 트렌드에 참여 중인 친구가 없습니다."가 반환됩니다.
![트렌드에 참여한 친구 X](https://github.com/HotCake-Tanghuru/HotCake-BE/assets/142385695/ca3759cd-d0d3-42cb-9f4c-06eb5ce9ad04)


- 팔로우 한 유저 중 트렌드 미션에 참여 중인 유저가 있다면 그 유저의 트렌드 아이템이 반환됩니다.
![20231219_160308](https://github.com/HotCake-Tanghuru/HotCake-BE/assets/142385695/73926462-5f5f-4ce6-9e14-c73713c6599b)
