### PR TITLE
✨ Feat: 핫 트렌드 상세 조회

### DIFF
--- a/trends/serializers.py
+++ b/trends/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Trend
+from .models import Trend, TrendItem
 
 
 class TrendSerializer(serializers.ModelSerializer):
@@ -8,7 +8,13 @@ class TrendSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "view_count", "created_at", "image"]
 
 
-class TrendItemSerializer(serializers.ModelSerializer):
+class TrendViewCountSerializer(serializers.ModelSerializer):
     class Meta:
         model = Trend
+        fields = ["view_count"]
+
+
+class TrendItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TrendItem
         fields = ["id", "trend", "title", "content", "image"]

--- a/trends/urls.py
+++ b/trends/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path("", views.TrendView.as_view(), name="trends"),
+    path("<int:trend_id>/", views.TrendDetailView.as_view(), name="trend_detail"),
 ]

--- a/trends/views.py
+++ b/trends/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 
@@ -6,7 +6,7 @@ from .models import Trend, TrendItem
 from accounts.models import User, Follow
 from trend_missions.models import UserTrendItem, TrendMission
 
-from .serializers import TrendSerializer, TrendItemSerializer
+from .serializers import TrendSerializer, TrendItemSerializer, TrendViewCountSerializer
 from trend_missions.serializers import UserTrendItemSerializer
 from accounts.serializers import UserSerializer
 
@@ -35,15 +35,61 @@ class TrendView(GenericAPIView):
 
         # 팔로우한 유저 여부 확인
         if not follow_list:
-            result["followed_trends"].append({"아직 팔로우한 친구가 없습니다."})
+            result["followed_trends"].append({"message":"아직 팔로우한 친구가 없습니다."})
 
         # 팔로우한 유저들의 트렌드 참여 여부 확인
         elif not user_trend_item_list:
-            result["followed_trends"].append({"아직 트렌드에 참여 중인 친구가 없습니다."})
+            result["followed_trends"].append({"message": "아직 트렌드에 참여 중인 친구가 없습니다."})
         else:
             trend_item_serializer = UserTrendItemSerializer(
                 user_trend_item_list, many=True
             )
             result["followed_trends"].extend(trend_item_serializer.data)
+
+        return Response(result, status=200)
+
+
+class TrendDetailView(GenericAPIView):
+    """트렌드 상세 조회"""
+
+    def get(self, request, trend_id):
+        # 페이지 조회수 증가
+        trend = get_object_or_404(Trend, id=trend_id)
+        trend.view_count += 1
+        trend.save()
+        trend_view_serializer = TrendViewCountSerializer(trend)
+
+        # 트렌드 아이템 조회
+        trend_item = TrendItem.objects.filter(trend=trend_id)
+        trend_item_serializer = TrendItemSerializer(trend_item, many=True)
+
+        # 해당 트렌드에 참여 중인 친구 조회
+        user = request.user
+        follow_list = Follow.objects.filter(from_user=user)
+        users_with_trend = []
+
+        for follow in follow_list:
+            user_trend_items = UserTrendItem.objects.filter(
+                user=follow.to_user, trend_item__trend=trend_id
+            )
+            if user_trend_items:
+                users_with_trend.append(follow.to_user)
+
+        result = {
+            "trend_view_count": trend_view_serializer.data,
+            "trend_item": trend_item_serializer.data,
+            "users_with_trend": [],
+        }
+
+        # 팔로우한 유저 여부 확인
+        if not follow_list:
+            result["users_with_trend"].append({"message":"아직 팔로우한 친구가 없습니다."})
+
+        # 팔로우한 유저들의 트렌드 참여 여부 확인
+        elif not users_with_trend:
+            result["users_with_trend"].append({"message":"아직 트렌드에 참여 중인 친구가 없습니다."})
+        else:
+            users_serializer = UserSerializer(users_with_trend, many=True)
+            result["users_with_trend"] = users_serializer.data
 
         return Response(result, status=200)


### PR DESCRIPTION
## 개요
핫 트렌드 상세 페이지에서 조회수와 해당 트렌드의 아이템들을 조회할 수 있도록 했습니다. 또 팔로잉 한 친구 중 해당 트렌드 인증 미션에 참가한 친구를 확인할 수 있도록 했습니다.

Resolves: #51 

## PR 유형
- [x] 새로운 기능 추가

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 테스트 코드를 작성하지 못하여 직접 테스트 했습니다.

- 팔로우 한 유저가 없는 경우 트렌드에 해당하는 트렌드 아이템과 함께 "아직 팔로우한 친구가 없습니다."가 반환됩니다.
![팔로우 X](https://github.com/HotCake-Tanghuru/HotCake-BE/assets/142385695/2121c38c-a0b4-4cac-b54a-72a553a88b5c)

- 팔로우 한 유저 중 해당 트렌드 미션에 참여 중인 유저가 없는 경우 "아직 트렌드에 참여 중인 친구가 없습니다."가 반환됩니다.
![트렌드 참여 친구 X](https://github.com/HotCake-Tanghuru/HotCake-BE/assets/142385695/c914eeec-2e5b-4aeb-8931-7a7a7bc06614)

- 팔로우 한 유저 중 트렌드 미션에 참여 중인 유저가 있다면 해당 유저의 정보가 반환됩니다.
![트렌드 참여 친구 O](https://github.com/HotCake-Tanghuru/HotCake-BE/assets/142385695/c6266422-1171-470a-8ddb-ea503192ed1f)
