### PR TITLE
✨Feat: 팔로우 API

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -2,7 +2,7 @@ from django.contrib.auth import authenticate
 from rest_framework import serializers, exceptions
 from rest_framework_simplejwt.tokens import RefreshToken, TokenError
 
-from .models import User, Like
+from .models import User, Like, Follow
 
 
 class UserSerializer(serializers.Serializer):
@@ -52,3 +52,13 @@ class LikeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Like
         fields = ["id", "user", "trend", "trend_mission"]
+
+class FollowSerializer(serializers.ModelSerializer):
+    user_info = UserSerializer(source="to_user", read_only=True)
+    class Meta:
+        model = Follow
+        fields = ["id", "from_user", "to_user", "user_info"]
+    
+    def create(self, validated_data):
+        follow = Follow.objects.create(**validated_data)
+        return follow

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -5,6 +5,7 @@ from accounts.views import KakaoCallback
 from accounts.models import User, Follow
 from rest_framework.test import APIClient
 
+
 class KakaoLoginTest(TestCase):
     """KakaoLogin 뷰에 대한 테스트 케이스"""
 
@@ -23,7 +24,8 @@ class KakaoLoginTest(TestCase):
 
 class KakaoCallbackTest(TestCase):
     """KakaoCallback 뷰에 대한 테스트 케이스"""
-    # views.py에서 
+
+    # views.py에서
     # request.session["kakao_access_token"] = kakao_access_token 부분을 지우고 테스트 수행!
     # 테스트 수행 후 다시 복구할 것!
     def setUp(self):
@@ -133,7 +135,7 @@ class FollowingTest(TestCase):
             "testuser",
             "testprofileimg",
             "testbio",
-            "123456789@"
+            "123456789@",
         )
         # 테스트 클라이언트 인증 방식
         self.client.force_authenticate(user=self.user)
@@ -146,7 +148,7 @@ class FollowingTest(TestCase):
             "testuser2",
             "testprofileimg",
             "testbio2",
-            "123456789@2"
+            "123456789@2",
         )
 
     # 팔로잉 목록 조회 테스트
@@ -154,9 +156,69 @@ class FollowingTest(TestCase):
         # 팔로잉 목록 조회
         response = self.client.get(f"/users/{self.user.id}/following")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-    
+
     # 팔로잉 목록 조회 실패 테스트 - 존재하지 않는 유저
     def test_following_list_fail(self):
         # 팔로잉 목록 조회
         response = self.client.get(f"/users/-2/following")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class FollowerTest(TestCase):
+    def setUp(self):
+        # 테스트를 위한 유저 생성
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            "kakao",
+            "123456789",
+            "test@gmail.com",
+            "testuser",
+            "testprofileimg",
+            "testbio",
+            "123456789@",
+        )
+        # 테스트 클라이언트 인증 방식
+        self.client.force_authenticate(user=self.user)
+
+        # 테스트를 위한 다른 유저 생성
+        self.user2 = User.objects.create_user(
+            "kakao2",
+            "1234567892",
+            "test2@gmail.com",
+            "testuser2",
+            "testprofileimg",
+            "testbio2",
+            "123456789@2",
+        )
+
+    # 팔로워 목록 조회 테스트
+    def test_follower_list(self):
+        # 팔로워 데이터 생성
+        Follow.objects.create(from_user=self.user2, to_user=self.user)
+        # 팔로워 목록 조회
+        response = self.client.get(f"/users/{self.user.id}/followers")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    # 팔로워 목록 조회 실패 테스트 - 존재하지 않는 유저
+    def test_follower_list_fail(self):
+        # 팔로워 목록 조회
+        response = self.client.get(f"/users/-2/followers")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # 팔로워 삭제 테스트
+    def test_follower_delete(self):
+        # 팔로워 데이터 생성
+        Follow.objects.create(from_user=self.user2, to_user=self.user)
+        # 팔로워 삭제
+        response = self.client.delete(
+            f"/users/{self.user.id}/followers", {"follower_user_id": self.user2.id}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    # 팔로워 삭제 실패 테스트 - 없는 팔로우 데이터
+    def test_follower_delete_fail(self):
+        # 팔로워 삭제
+        response = self.client.delete(
+            f"/users/{self.user.id}/followers", {"follower_user_id": self.user2.id}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,6 +6,7 @@ from accounts.views import (
     KakaoLogoutCallback,
     KakaoUnlink,
     FollowingView,
+    FollowerView,
 )
 
 urlpatterns = [
@@ -20,5 +21,5 @@ urlpatterns = [
     path("oauth/kakao/unlink/", KakaoUnlink.as_view(), name="kakao_unlink"),
 
     path("users/<int:user_id>/following", FollowingView.as_view(), name="following"),
-    
+    path("users/<int:user_id>/followers", FollowerView.as_view(), name="followers"),
 ]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -5,6 +5,7 @@ from accounts.views import (
     KakaoLogout,
     KakaoLogoutCallback,
     KakaoUnlink,
+    FollowingView,
 )
 
 urlpatterns = [
@@ -17,4 +18,7 @@ urlpatterns = [
         name="kakao_logout_callback",
     ),
     path("oauth/kakao/unlink/", KakaoUnlink.as_view(), name="kakao_unlink"),
+
+    path("users/<int:user_id>/following", FollowingView.as_view(), name="following"),
+    
 ]


### PR DESCRIPTION
- 기능 구현
  - 팔로잉 조회 - url에 사용자의 id값을 담아 해당 유저의 팔로잉 정보 반환 - 팔로잉 정보에는 대상하는 사용자의 정보 포함

  - 팔로잉 추가&삭제
    - 팔로잉 할 사용자의 id를 json으로 담아 전송
    - 이미 팔로잉 중이라면 팔로잉 삭제, 아니라면 팔로잉 추가 - 하나의 요청으로 동시에 처리

  - 팔로워 조회&삭제
    - url에 사용자의 아이디값을 담아 요청
    - 해당하는 사용자의 팔로워 목록 반환
    - 팔로워 목록을 확인하고, 팔로워 데이터 삭제 가능

- 비고
  - 테스트 실행 완료

## 개요
Resolves: #12 #58

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 테스트 추가, 테스트 리팩토링


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] 변경 사항에 대한 테스트를 했습니다.
