### PR TITLE
♻️ Refactor: accounts앱 swagger 적용

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -244,7 +244,7 @@ class FollowerTest(TestCase):
         Follow.objects.create(from_user=self.user2, to_user=self.user)
         # 팔로워 삭제
         response = self.client.delete(
-            f"/users/{self.user.id}/followers", {"follower_user_id": self.user2.id}
+            f"/users/{self.user2.id}/followers"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -252,7 +252,7 @@ class FollowerTest(TestCase):
     def test_follower_delete_fail(self):
         # 팔로워 삭제
         response = self.client.delete(
-            f"/users/{self.user.id}/followers", {"follower_user_id": self.user2.id}
+            f"/users/{self.user2.id}/followers"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -275,5 +275,5 @@ class SearchByNicknameTest(TestCase):
         # 닉네임으로 유저 검색 테스트
     def test_search_by_nickname(self):      
 
-        response = self.client.get(f"/users/test")
+        response = self.client.get(f"/users/search?nickname=testuser")
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -13,7 +13,6 @@ urlpatterns = [
         name="kakao_logout_callback",
     ),
     path("oauth/kakao/unlink/", views.KakaoUnlink.as_view(), name="kakao_unlink"),
-    path("oauth/kakao/unlink/", views.KakaoUnlink.as_view(), name="kakao_unlink"),
     path("users/<int:pk>", views.UserProfileView.as_view(), name="user_detail"),
     path("users/<int:user_id>/following", views.FollowingView.as_view(), name="following"),
     path("users/<int:user_id>/followers", views.FollowerView.as_view(), name="followers"),


### PR DESCRIPTION
## 개요

- 팔로잉 로직 변경
  - 팔로잉 대상의 사용자 id를 json에 담지 않고 url에 담아 요청을 전송합게끔 변경하였습니다.

- accounts앱에 swagger를 적용하였습니다.
  - 카카오 로그인, 로그아웃, 회원 탈퇴의 경우 별도의 카카오 페이지로 이동해야만 가능하여 적용하지 못했습니다.

- 비고
  - 테스트 수행 완료


 Resolves: #48

## PR 유형
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
