### PR TITLE
♻️ Refactor: 카카오 로그인&로그아웃 API 분리

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,6 +6,9 @@ from accounts import views
 urlpatterns = [
     path("oauth/kakao/login/", views.KakaoLogin.as_view(), name="kakao_login"),
     path("oauth/kakao/callback/", views.KakaoCallback.as_view(), name="kakao_callback"),
+    path("oauth/kakao/login/fe", views.KakaoLoginFE.as_view(), name="kakao_login"),
+    path("oauth/kakao/callback/fe", views.KakaoCallbackFE.as_view(), name="kakao_callback"),
+
     path("oauth/kakao/logout/", views.KakaoLogout.as_view(), name="kakao_logout"),
     path(
         "oauth/kakao/logout/callback/",

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -35,6 +35,9 @@ kakao_user_uri = "https://kapi.kakao.com/v2/user/me"
 kakao_logout_uri = "https://kauth.kakao.com/oauth/logout"
 kakao_unlink_uri = "https://kapi.kakao.com/v1/user/unlink"
 
+KAKAO_REDIRECT_URI_FE = env("HOTCAKE_URL")
+KAKAO_LOGOUT_REDIRECT_URI_FE = env("HOTCAKE_URL")
+
 
 class KakaoLogin(APIView):
     permission_classes = [AllowAny]
@@ -48,6 +51,17 @@ class KakaoLogin(APIView):
         """카카오 인가 코드를 받기 위한 url을 만들어서 리다이렉트"""
         client_id = env("KAKAO_REST_API_KEY")
         redirect_uri = env("KAKAO_REDIRECT_URI")
+        uri = f"{kakao_login_uri}?client_id={client_id}&redirect_uri={redirect_uri}&response_type=code"
+        res = redirect(uri)
+        return res
+    
+class KakaoLoginFE(APIView):
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        """카카오 인가 코드를 받기 위한 url을 만들어서 리다이렉트"""
+        client_id = env("KAKAO_REST_API_KEY")
+        redirect_uri = KAKAO_REDIRECT_URI_FE
         uri = f"{kakao_login_uri}?client_id={client_id}&redirect_uri={redirect_uri}&response_type=code"
         res = redirect(uri)
         return res
@@ -149,8 +163,111 @@ class KakaoCallback(APIView):
         }
 
         response = Response(res, status=status.HTTP_200_OK)
+        
         return response
 
+class KakaoCallbackFE(APIView):
+    permission_classes = [AllowAny]
+    serializer_class = UserSerializer
+    
+    @extend_schema(exclude=True)
+    def get(self, request):
+        """access_token과 회원정보를 요청"""
+        # access_token 요청
+        code = request.GET.get("code")
+        if not code:
+            return Response(
+                {"message": "code가 없습니다."}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        request_data = {
+            "grant_type": "authorization_code",
+            "client_id": env("KAKAO_REST_API_KEY"),
+            "redirect_uri": KAKAO_LOGOUT_REDIRECT_URI_FE,
+            "client_secret": env("KAKAO_CLIENT_SECRET_KEY"),
+            "code": code,
+        }
+        token_headers = {
+            "Content-type": "application/x-www-form-urlencoded;charset=utf-8"
+        }
+        token_res = requests.post(
+            kakao_token_uri, data=request_data, headers=token_headers
+        )
+
+        token_json = token_res.json()
+        kakao_access_token = token_json.get("access_token")
+
+        if not kakao_access_token:
+            return Response(
+                {"message": "access_token이 없습니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        request.session["kakao_access_token"] = kakao_access_token
+
+        kakao_access_token = f"Bearer {kakao_access_token}"
+
+        # 카카오 회원정보 요청
+        auth_headers = {
+            "Authorization": kakao_access_token,
+            "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+        }
+        user_info_res = requests.post(kakao_user_uri, headers=auth_headers)
+        user_info_json = user_info_res.json()
+
+        social_type = "kakao"
+        social_id = f"{social_type}_{user_info_json.get('id')}"
+
+        kakao_account = user_info_json.get("kakao_account")
+
+        if not kakao_account:
+            return Response(
+                {"message": "카카오 계정이 없습니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        user_email = kakao_account.get("email")
+        profile = kakao_account.get("profile")
+
+        user_nickname = profile.get("nickname")
+        user_profile_img = profile.get("profile_image_url")
+
+        user, created = User.objects.get_or_create(
+            social_id=social_id,
+            defaults={
+                "social_type": social_type,
+                "social_id": social_id,
+                "email": user_email,
+                "nickname": user_nickname,
+                "profile_img": user_profile_img,
+            },
+        )
+
+        # 생성된 경우와 기존 사용자인 경우에 따라 다른 메시지 반환
+        if created:
+            message = "사용자 생성 완료"
+        else:
+            message = "로그인 완료"
+
+        # JWT 토큰 생성
+        refresh = RefreshToken.for_user(user)
+        access_token = str(refresh.access_token)
+        refresh_token = str(refresh)
+
+        res = {
+            "message": message,
+            "user": UserSerializer(user).data,
+            "user_id": user.id,
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        }
+
+        # # jwt 토큰 => 쿠키에 저장
+        # res.set_cookie("access", access_token, httponly=True)
+        # res.set_cookie("refresh", refresh_token, httponly=True)
+
+        response = Response(res, status=status.HTTP_200_OK)
+        return response
+    
 
 class KakaoLogout(APIView):
     permission_classes = [AllowAny]
@@ -165,6 +282,14 @@ class KakaoLogout(APIView):
         client_id = env("KAKAO_REST_API_KEY")
         logout_redirect_uri = env("KAKAO_LOGOUT_REDIRECT_URI")
         uri = f"{kakao_logout_uri}?client_id={client_id}&logout_redirect_uri={logout_redirect_uri}"
+
+        response = Response({
+            "message": "Logout success"
+            }, 
+            status=status.HTTP_202_ACCEPTED
+        )
+        response.set_cookie("access", '', httponly=True)
+        response.set_cookie("refresh", '', httponly=True)
         res = redirect(uri)
         return res
 
@@ -180,7 +305,7 @@ class KakaoLogoutCallback(APIView):
 
         serializer.is_valid(raise_exception=True)
         serializer.save()
-
+        
         return Response(status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
- 백엔드서버에서 카카오 로그인 시도 시 redirect되는 url과 실제 배포된 프론트에서 redirect url 분리 필요

- 메소드를 각각 분리

- 프론트 url 환경변수로 설정



## PR 유형
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
