### PR TITLE
♻️ Refactor: 카카오 로그인 api 분리

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,8 +6,9 @@ from accounts import views
 urlpatterns = [
     path("oauth/kakao/login/", views.KakaoLogin.as_view(), name="kakao_login"),
     path("oauth/kakao/callback/", views.KakaoCallback.as_view(), name="kakao_callback"),
-    path("oauth/kakao/login/fe", views.KakaoLoginFE.as_view(), name="kakao_login"),
-    path("oauth/kakao/callback/fe", views.KakaoCallbackFE.as_view(), name="kakao_callback"),
+
+    path("oauth/kakao/login/fe", views.KakaoLoginFE.as_view(), name="kakao_login_fe"),
+    path('oauth/kakao/callback/fe', views.KakaoLoginFE.as_view(), name='kakao_callback_fe'),
 
     path("oauth/kakao/logout/", views.KakaoLogout.as_view(), name="kakao_logout"),
     path(
@@ -21,4 +22,6 @@ urlpatterns = [
     path("users/<int:user_id>/followers", views.FollowerView.as_view(), name="followers"),
     path("users/search", views.UserSearch.as_view(), name="follow"),
     path("users/info", views.UserInfo.as_view(), name="user_info"),
+    # path('kakao/login/finish/', views.kakaoLoginFinish.as_view(),
+    #     name='kakao_login_todjango'),
 ]


### PR DESCRIPTION
## 개요
♻️ Refactor: 카카오 로그인 api 분리

- 실제 서비스에서 소셜 로그인시 프론트 페이지로 redirect하기 위해 서비스용 api와 백엔드에서 확인하기 위한 api를 분리하였습니다.

## PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링


## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.
